### PR TITLE
README: Add Ubuntu 17/19, Manjaro 18, Debian 11, Fedora 33

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,11 +120,17 @@ sh-4.4# id
 uid=0(user) gid=0(root) groups=0(root)
 ```
 
-The exploit was written to work on as more distroes as possible, it was tested to be working on
+The exploit was written to work on as many distros as possible. It was confirmed to be working on:
 
+* CentOS 8/Stream (4.18.0-80.el8.x86_64 ~ xxx)
+* Debian 11 (5.10.0-8-amd64 ~ xxx)
+* Fedora 33 (5.8.15-301.fc33.x86_64 ~ xxx)
+* Manjaro 18 (xxx ~ xxx)
+* RHEL 8 (4.18.0-80.el8.x86_64 ~ xxx)
+* Ubuntu 17 (4.10.0-19-generic ~ xxx)
 * Ubuntu 18 (xxx ~ xxx)
+* Ubuntu 19 (5.0.0-38-generic ~ xxx)
 * Ubuntu 20 (xxx ~ xxx)
-* Centos 8/Stream (xxx ~ xxx)
 
 (Please feel free to send a PR to update this if you find it could work on other kernels.)
 


### PR DESCRIPTION
Tested on:

* CentOS 8 (1905) kernel 4.18.0-80.el8.x86_64
* Debian 11.0.0 kernel 5.10.0-8-amd64
* Debian 11.4.0 kernel 5.10.0-16-amd64
* Fedora 33 kernel 5.8.15-301.fc33.x86_64
* Manjaro 18.1.0 kernel 5.2.11-1-MANJARO
* RHEL 8.0 kernel 4.18.0-80.el8.x86_64
* Ubuntu 17.04 kernel 4.10.0-19-generic
* Ubuntu 19.04 kernel 5.0.0-38-generic

These are the default kernels for each distro release.

Failure and/or system freeze on:

* Fedora 35 kernel 5.14.10-300.fc35.x86_64
* Fedora 36 kernel 5.17.5-300.fc36.x86_64
* OpenSUSE 15.0 kernel 4.12.14-lp150.11-default

I haven't investigated the fail cases.
